### PR TITLE
Updated Parameters tab 'Fresh Water' to 'Fresh'

### DIFF
--- a/client/src/components/app/Parameters.vue
+++ b/client/src/components/app/Parameters.vue
@@ -169,7 +169,7 @@ export default {
         if (v === 'Fresh') {
           return {
             id: v,
-            name: 'Fresh Water',
+            name: 'Fresh',
           };
         }
         return {


### PR DESCRIPTION
Parameters tab now reads 'Fresh' instead of 'Fresh Water'. This will eliminate the duplicate 'Fresh Water water' from the text below.