### PR TITLE
Initial 'Water Concerns' select and displaying 'Water Concerns' in 'Parameters by Location' sidebar

### DIFF
--- a/client/src/components/app/Concerns.vue
+++ b/client/src/components/app/Concerns.vue
@@ -148,7 +148,6 @@ export default {
       const checkedValue = event.target.value;
       // Checks to see if 'waterConcerns' exists as an empty AquaQAPP wwill not have 'waterConcerns' until an item is selected
       if (!('waterConcerns' in this.pendingData) && (checkedValue === 'GENPHYS' || checkedValue === 'GENBENTHIC')) {
-        console.log('hit');
         if (checkedValue === 'GENPHYS' && !event.target.checked) {
           this.$emit('updateData', { target: { value: 'GENBENTHIC' } }, this.concernsQuestion);
         } else if (checkedValue === 'GENBENTHIC' && event.target.checked) {

--- a/client/src/components/app/Concerns.vue
+++ b/client/src/components/app/Concerns.vue
@@ -146,9 +146,17 @@ export default {
     },
     updateConcern(event) {
       const checkedValue = event.target.value;
-
+      // Checks to see if 'waterConcerns' exists as an empty AquaQAPP wwill not have 'waterConcerns' until an item is selected
+      if (!('waterConcerns' in this.pendingData) && (checkedValue === 'GENPHYS' || checkedValue === 'GENBENTHIC')) {
+        console.log('hit');
+        if (checkedValue === 'GENPHYS' && !event.target.checked) {
+          this.$emit('updateData', { target: { value: 'GENBENTHIC' } }, this.concernsQuestion);
+        } else if (checkedValue === 'GENBENTHIC' && event.target.checked) {
+          this.$emit('updateData', { target: { value: 'GENPHYS' } }, this.concernsQuestion);
+        }
+      }
       // Unchecking GEHPHYS unchecks GENBENTHIC
-      if (
+      else if (
         checkedValue === 'GENPHYS' &&
         this.pendingData.waterConcerns.includes('GENBENTHIC') &&
         !event.target.checked

--- a/client/src/components/app/ParametersByLocation.vue
+++ b/client/src/components/app/ParametersByLocation.vue
@@ -176,6 +176,11 @@ export default {
             location['Water Quality Concerns'].split(',').includes(concern.code)
           );
           location.waterConcerns = locationConcerns.map((c) => c.label).join(', ');
+        } else {
+          const locationConcerns = this.concerns.filter((concern) =>
+            this.qappData.waterConcerns.split(',').includes(concern.code)
+          );
+          location.waterConcerns = locationConcerns.map((c) => c.label).join(', ');
         }
         locations.push(location);
       });


### PR DESCRIPTION
When selecting GENPHYS or GENBENTHIC for an empty AquaQAPP, an error is no longer thrown. Parameters by Location now displayed the Water Concerns in the sidebar.